### PR TITLE
Add downloadOptions and interlex annotations to DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -24,22 +24,26 @@
   "types": [
     {
       "information": {
-        "value": "Clinical"
+        "value": "Clinical",
+		"valueIRI": "http://uri.interlex.org/ilx_0102254"
       }
     },
     {
       "information": {
-        "value": "Genomics"
+        "value": "Genomics",
+		"valueIRI": "http://uri.interlex.org/ilx_0741204"
       }
     },
     {
       "information": {
-        "value": "Neuroimaging"
+        "value": "Neuroimaging",
+		"valueIRI": "http://uri.interlex.org/ilx_0741206"
       }
     },
     {
       "information": {
-        "value": "Demographics"
+        "value": "Demographics",
+		"valueIRI": "http://uri.interlex.org/ilx_0103016"
       }
     },
     {
@@ -59,17 +63,20 @@
     },
     {
       "information": {
-        "value": "Angio"
+        "value": "Angio",
+		"valueIRI": "http://uri.interlex.org/ilx_0100622"
       }
     },
     {
       "information": {
-        "value": "CT"
+        "value": "CT",
+		"valueIRI": "http://uri.interlex.org/ilx_0778786"
       }
     },
     {
       "information": {
-        "value": "DTI"
+        "value": "DTI",
+		"valueIRI": "http://uri.interlex.org/ilx_0103240"
       }
     },
     {
@@ -79,7 +86,8 @@
     },
     {
       "information": {
-        "value": "MRS"
+        "value": "MRS",
+		"valueIRI": "http://uri.interlex.org/ilx_0106464"
       }
     }
   ],

--- a/DATS.json
+++ b/DATS.json
@@ -332,6 +332,14 @@
         }
       ]
     },
+	{
+		"category": "downloadOptions",
+		"values": [
+			{
+				"value": "offsite"
+			}
+		]
+	},
     {
       "category": "REB_statement",
       "values": [


### PR DESCRIPTION
This PR updates `DATS.json` with a downloadOptions entry containing the dummy value "offsite", and also adds interlex annotations to keywords.